### PR TITLE
Fix STAB display

### DIFF
--- a/src/components/Run/MoveCard/MoveCard.tsx
+++ b/src/components/Run/MoveCard/MoveCard.tsx
@@ -16,6 +16,27 @@ const MoveCard: React.FC<Props> = (props: Props) => {
     // Component state
     const [show, setShow] = useState<boolean>(false);
 
+    // Determines if move should display STAB
+    const hasSTABDisplay = (): boolean => {
+        if (props.move && props.isSTAB) {
+            const invalidSTAB: string[] = [
+                "sonic-boom",
+                "dragon-rage",
+                "night-shade",
+                "seismic-toss",
+                "counter",
+                "mirror-coat",
+                "future-sight",
+                "doom-desire",
+                "bide",
+                "beat-up",
+            ];
+            return props.isSTAB && props.move.category !== "other" && !invalidSTAB.includes(props.move.slug);
+        } else {
+            return false;
+        }
+    };
+
     return (
         <div className={styles["move-card"]} onMouseEnter={() => setShow(true)} onMouseLeave={() => setShow(false)}>
             <div className={styles.row}>
@@ -37,10 +58,13 @@ const MoveCard: React.FC<Props> = (props: Props) => {
                         />
                     </div>
                 </div>
-                {props.isSTAB && props.move.power > 0 ? (
+                {hasSTABDisplay() ? (
                     <div className={styles.bp}>
                         <p className={styles.text}>
-                            BP: <strong className={styles["stab-text"]}>{props.move.power * 1.5}</strong>
+                            BP:{" "}
+                            <strong className={styles["stab-text"]}>
+                                {props.move.power === 0 ? "--" : props.move.power * 1.5}
+                            </strong>
                         </p>
                         <div className={styles["stab-icon"]}>
                             <Image

--- a/src/static/bugs.ts
+++ b/src/static/bugs.ts
@@ -44,10 +44,6 @@ const bugs: { [priority: string]: Bug[] } = {
             group: "General",
         },
         {
-            desc: "Damaging moves with no BP (ex: Grass Knot) don't display a STAB bonus",
-            group: "General",
-        },
-        {
             desc: "Some tooltips overflow the screen on mobile",
             group: "General",
         },

--- a/src/static/emerald.ts
+++ b/src/static/emerald.ts
@@ -23,14 +23,14 @@ const emerald: GameGroup = {
                     segment: {},
                 },
                 {
-                    slug: "hoenn-route-103",
-                    name: "Route 103",
+                    slug: "oldale-town",
+                    name: "Oldale Town",
                     type: "location",
                     segment: {},
                 },
                 {
-                    slug: "oldale-town",
-                    name: "Oldale Town",
+                    slug: "hoenn-route-103",
+                    name: "Route 103",
                     type: "location",
                     segment: {},
                 },


### PR DESCRIPTION
- Allow indeterminate BP moves to have a STAB display in `MoveCard`
- Construct list of moves that shouldn't have STAB (i.e., Night Shade)