### PR TITLE
Ability fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ The most up-to-date version of NuzDocs is currently deployed at: https://nuzdocs
 -   [ ] Nicer alerts for exports
 -   [ ] Double battle indicator
 -   [ ] Required battle indicator
+-   [ ] Dynamic default nicknames
 
 ## License
 

--- a/src/components/Global/Dropdown/Dropdown.tsx
+++ b/src/components/Global/Dropdown/Dropdown.tsx
@@ -44,7 +44,7 @@ const Dropdown: React.FC<Props> = (props: Props) => {
                 onClick={() => setOpen(false)}
                 onScroll={() => setOpen(false)}
             />
-            <div className={styles.controller} onClick={() => setOpen(true)} style={getStyling()}>
+            <div className={styles.controller} onClick={() => setOpen(props.options.length > 0)} style={getStyling()}>
                 <p className={styles.display}>{props.value ? props.value : props.placeholder}</p>
                 <div className={`${styles.arrow} ${open ? styles.flipped : ""} disable-select`}>
                     <Image

--- a/src/components/Pokedex/PokedexPage/PokedexPage.tsx
+++ b/src/components/Pokedex/PokedexPage/PokedexPage.tsx
@@ -11,6 +11,7 @@ import { fetchPokemon } from "@/utils/api";
 import { getPokemonTier } from "@/utils/utils";
 import { useEffect, useState } from "react";
 import styles from "./PokedexPage.module.scss";
+import PokemonAbility from "@/models/PokemonAbility";
 
 type Props = {
     pokemon: string;
@@ -50,7 +51,10 @@ const PokedexPage: React.FC<Props> = (props: Props) => {
                 <PokemonDisplay pokemon={pokemon} runID={props.run.id} />
                 <TierCard tier={getPokemonTier(props.pokemon, props.run.gameSlug)} />
             </div>
-            <Abilities abilities={pokemon.abilities} game={props.run.gameSlug} />
+            <Abilities
+                abilities={pokemon.abilities.map((ability: PokemonAbility) => ability.slug)}
+                game={props.run.gameSlug}
+            />
             <BaseStats stats={pokemon.stats} />
             <Learnset moves={learnset} game={props.run.gameSlug} />
             {pokemon.evolutions.some((chain: string[]) => chain.length > 1) ? (

--- a/src/components/Summary/SummaryInfo/SummaryInfo.tsx
+++ b/src/components/Summary/SummaryInfo/SummaryInfo.tsx
@@ -1,7 +1,6 @@
 import Dropdown from "@/components/Global/Dropdown/Dropdown";
 import AbilityData from "@/models/AbilityData";
 import CaughtPokemon from "@/models/CaughtPokemon";
-import NamedResource from "@/models/NamedResource";
 import PokemonAbility from "@/models/PokemonAbility";
 import PokemonData from "@/models/PokemonData";
 import { fetchAbilities } from "@/utils/api";
@@ -17,7 +16,7 @@ type Props = {
     pokemonData: PokemonData;
     game: string;
     onLevelUpdate: (level: number) => void;
-    onAbilityUpdate: (ability: NamedResource) => void;
+    onAbilityUpdate: (num: number) => void;
     onNatureUpdate: (nature: string) => void;
 };
 
@@ -101,15 +100,9 @@ const SummaryInfo: React.FC<Props> = (props: Props) => {
                 <div className={styles.value}>
                     <Dropdown
                         placeholder="???"
-                        value={
-                            abilities.length > 0 && props.caughtPokemon.pokemon.ability
-                                ? props.caughtPokemon.pokemon.ability.name
-                                : null
-                        }
+                        value={abilities.length > 0 ? abilities[props.caughtPokemon.abilityNum - 1].name : null}
                         options={getAbilityNames()}
-                        onSelect={(name: string) =>
-                            props.onAbilityUpdate(initNamedResource(getAbilitySlug(name), name))
-                        }
+                        onSelect={(name: string) => props.onAbilityUpdate(getAbilityNames().indexOf(name) + 1)}
                         border={false}
                         minWidth={150}
                     />

--- a/src/components/Summary/SummaryInfo/SummaryInfo.tsx
+++ b/src/components/Summary/SummaryInfo/SummaryInfo.tsx
@@ -2,14 +2,15 @@ import Dropdown from "@/components/Global/Dropdown/Dropdown";
 import AbilityData from "@/models/AbilityData";
 import CaughtPokemon from "@/models/CaughtPokemon";
 import NamedResource from "@/models/NamedResource";
+import PokemonAbility from "@/models/PokemonAbility";
 import PokemonData from "@/models/PokemonData";
 import { fetchAbilities } from "@/utils/api";
+import { initNamedResource } from "@/utils/initializers";
 import { getListOfNatures } from "@/utils/natures";
 import { getTypeCardSrc } from "@/utils/utils";
 import Image from "next/image";
 import { ChangeEvent, useEffect, useState } from "react";
 import styles from "./SummaryInfo.module.scss";
-import { initNamedResource } from "@/utils/initializers";
 
 type Props = {
     caughtPokemon: CaughtPokemon;
@@ -59,9 +60,10 @@ const SummaryInfo: React.FC<Props> = (props: Props) => {
     // Fetch the ability data for the given Pokemon on component load
     useEffect(() => {
         if (props.pokemonData && props.game) {
-            fetchAbilities(props.pokemonData.abilities, props.game).then((abilities: AbilityData[]) =>
-                setAbilities(abilities)
-            );
+            fetchAbilities(
+                props.pokemonData.abilities.map((ability: PokemonAbility) => ability.slug),
+                props.game
+            ).then((abilities: AbilityData[]) => setAbilities(abilities));
         }
     }, [props.pokemonData, props.game]);
 

--- a/src/components/Summary/SummaryInfo/SummaryInfo.tsx
+++ b/src/components/Summary/SummaryInfo/SummaryInfo.tsx
@@ -100,9 +100,27 @@ const SummaryInfo: React.FC<Props> = (props: Props) => {
                 <div className={styles.value}>
                     <Dropdown
                         placeholder="???"
-                        value={abilities.length > 0 ? abilities[props.caughtPokemon.abilityNum - 1].name : null}
+                        value={
+                            abilities.length > 0
+                                ? abilities.find(
+                                      (ability: AbilityData) =>
+                                          props.pokemonData.abilities.find(
+                                              (ability: PokemonAbility) =>
+                                                  ability.slot === props.caughtPokemon.abilityNum
+                                          )!.slug === ability.slug
+                                  )!.name
+                                : null
+                        }
                         options={getAbilityNames()}
-                        onSelect={(name: string) => props.onAbilityUpdate(getAbilityNames().indexOf(name) + 1)}
+                        onSelect={(name: string) =>
+                            props.onAbilityUpdate(
+                                props.pokemonData.abilities.find(
+                                    (ability: PokemonAbility) =>
+                                        ability.slug ===
+                                        abilities.find((ability: AbilityData) => ability.name === name)!.slug
+                                )!.slot
+                            )
+                        }
                         border={false}
                         minWidth={150}
                     />

--- a/src/components/Summary/SummaryPage/SummaryPage.tsx
+++ b/src/components/Summary/SummaryPage/SummaryPage.tsx
@@ -1,16 +1,16 @@
 import Modal from "@/components/Global/Modal/Modal";
 import MoveModal from "@/components/Summary/MoveModal/MoveModal";
 import Moveset from "@/components/Summary/Moveset/Moveset";
+import Stats from "@/components/Summary/Stats/Stats";
 import SummaryHeader from "@/components/Summary/SummaryHeader/SummaryHeader";
 import SummaryInfo from "@/components/Summary/SummaryInfo/SummaryInfo";
-import Stats from "@/components/Summary/Stats/Stats";
 import CaughtPokemon from "@/models/CaughtPokemon";
 import NamedResource from "@/models/NamedResource";
 import PokemonData from "@/models/PokemonData";
 import Run from "@/models/Run";
 import Values from "@/models/Values";
 import { fetchPokemon } from "@/utils/api";
-import { getBox, getRIPs, getRun, isAlive, updateBox, updateRIPs } from "@/utils/run";
+import { getRun, isAlive, updateBox, updateRIPs } from "@/utils/run";
 import { useEffect, useState } from "react";
 import styles from "./SummaryPage.module.scss";
 
@@ -45,9 +45,9 @@ const SummaryPage: React.FC<Props> = (props: Props) => {
     };
 
     // Update ability in local storage
-    const handleAbilityUpdate = (ability: NamedResource): void => {
+    const handleAbilityUpdate = (num: number): void => {
         const newCaughtPokemon: CaughtPokemon = JSON.parse(JSON.stringify(caughtPokemon));
-        newCaughtPokemon.pokemon.ability = ability;
+        newCaughtPokemon.abilityNum = num;
         handleUpdate(newCaughtPokemon);
     };
 
@@ -87,13 +87,13 @@ const SummaryPage: React.FC<Props> = (props: Props) => {
     };
 
     // Update Pokemon in local storage
-    const handleUpdate = (newPokemon: CaughtPokemon): void => {
-        if (isAlive(props.run.id, newPokemon.id)) {
-            updateBox(props.run.id, newPokemon);
+    const handleUpdate = (pokemon: CaughtPokemon): void => {
+        if (isAlive(props.run.id, pokemon.id)) {
+            updateBox(props.run.id, pokemon);
         } else {
-            updateRIPs(props.run.id, newPokemon);
+            updateRIPs(props.run.id, pokemon);
         }
-        setCaughtPokemon(newPokemon);
+        setCaughtPokemon(pokemon);
         setSelectedIdx(null);
         setMoveModalOpen(false);
     };
@@ -107,6 +107,8 @@ const SummaryPage: React.FC<Props> = (props: Props) => {
     // Find Pokemon on page load
     useEffect(() => {
         if (props.run && props.pokemonID) {
+            setCaughtPokemon(null);
+            setPokemonData(null);
             const pokemonList: CaughtPokemon[] = isAlive(props.run.id, props.pokemonID)
                 ? getRun(props.run.id).box
                 : getRun(props.run.id).rips;
@@ -133,7 +135,7 @@ const SummaryPage: React.FC<Props> = (props: Props) => {
                 pokemonData={pokemonData}
                 game={props.run.gameSlug}
                 onLevelUpdate={(level: number) => handleLevelUpdate(level)}
-                onAbilityUpdate={(ability: NamedResource) => handleAbilityUpdate(ability)}
+                onAbilityUpdate={(num: number) => handleAbilityUpdate(num)}
                 onNatureUpdate={(nature: string) => handleNatureUpdate(nature)}
             />
             <Moveset

--- a/src/models/CaughtPokemon.ts
+++ b/src/models/CaughtPokemon.ts
@@ -6,4 +6,5 @@ export default interface CaughtPokemon {
     nickname: string;
     locationSlug: string;
     pastSlugs: string[];
+    abilityNum: number;
 }

--- a/src/models/Pokemon.ts
+++ b/src/models/Pokemon.ts
@@ -7,7 +7,6 @@ export default interface Pokemon {
     level?: number;
     nature?: string;
     ability?: NamedResource;
-    abilityNum?: number;
     item?: NamedResource;
     moves: NamedResource[];
     ivs: Values;

--- a/src/models/Pokemon.ts
+++ b/src/models/Pokemon.ts
@@ -7,6 +7,7 @@ export default interface Pokemon {
     level?: number;
     nature?: string;
     ability?: NamedResource;
+    abilityNum?: number;
     item?: NamedResource;
     moves: NamedResource[];
     ivs: Values;

--- a/src/models/PokemonAbility.ts
+++ b/src/models/PokemonAbility.ts
@@ -1,0 +1,5 @@
+export default interface PokemonAbility {
+    slug: string;
+    hidden: boolean;
+    slot: number;
+}

--- a/src/models/PokemonData.ts
+++ b/src/models/PokemonData.ts
@@ -1,3 +1,4 @@
+import PokemonAbility from "@/models/PokemonAbility";
 import PokemonMove from "@/models/PokemonMove";
 import PokemonName from "@/models/PokemonName";
 import Stat from "@/models/Stat";
@@ -9,6 +10,6 @@ export default interface PokemonData {
     stats: Stat[];
     evolutions: string[][];
     forms: string[];
-    abilities: string[];
+    abilities: PokemonAbility[];
     movepool: PokemonMove[];
 }

--- a/src/pages/api/pokemon.ts
+++ b/src/pages/api/pokemon.ts
@@ -1,6 +1,7 @@
+import MyPokemonAbility from "@/models/PokemonAbility";
 import PokemonData from "@/models/PokemonData";
 import priorities from "@/static/priorities";
-import { initPokemonData } from "@/utils/initializers";
+import { initPokemonAbility, initPokemonData } from "@/utils/initializers";
 import { isInvalidForm } from "@/utils/utils";
 import type { NextApiRequest, NextApiResponse } from "next";
 import {
@@ -76,18 +77,15 @@ const fetchPokemonEvolutionChains = async (species: PokemonSpecies): Promise<str
     }
 };
 
-const fetchPokemon = async (pokemonSlug: string, generation: string, group: string): Promise<PokemonData> => {
+const fetchPokemon = async (slug: string, generation: string, group: string): Promise<PokemonData> => {
     const api: PokemonClient = new PokemonClient();
     try {
-        const pokemon: Pokemon = await api.getPokemonByName(pokemonSlug);
+        const pokemon: Pokemon = await api.getPokemonByName(slug);
         const species: PokemonSpecies = await api.getPokemonSpeciesByName(pokemon.species.name);
         const evolutions: string[][] = await fetchPokemonEvolutionChains(species);
-        const abilities: string[] =
-            priorities.generations.indexOf(generation) < 5
-                ? pokemon.abilities
-                      .filter((ability: PokemonAbility) => !ability.is_hidden)
-                      .map((ability: PokemonAbility) => ability.ability.name)
-                : pokemon.abilities.map((ability: PokemonAbility) => ability.ability.name);
+        const abilities: MyPokemonAbility[] = pokemon.abilities
+            .filter((ability: PokemonAbility) => !ability.is_hidden || priorities.generations.indexOf(generation) >= 4)
+            .map((ability: PokemonAbility) => initPokemonAbility(ability));
         return initPokemonData(pokemon, species, evolutions, abilities, generation, group);
     } catch (error: any) {
         throw error;

--- a/src/static/bugs.ts
+++ b/src/static/bugs.ts
@@ -34,7 +34,7 @@ const bugs: { [priority: string]: Bug[] } = {
             group: "General",
         },
         {
-            desc: "Pokemon abilities carry through when they evolve, even when they can no longer have that abiilty",
+            desc: "There's currently no way to detect if a Pokemon has a non-hidden ability that is only available in later generations",
             group: "General",
         },
     ],

--- a/src/utils/initializers.ts
+++ b/src/utils/initializers.ts
@@ -127,6 +127,7 @@ export const initCaughtPokemon = (pokemon: MyPokemon, locationSlug: string, runI
         nickname: pokemon.species,
         locationSlug: locationSlug,
         pastSlugs: [pokemon.slug],
+        abilityNum: 1,
     };
 };
 

--- a/src/utils/initializers.ts
+++ b/src/utils/initializers.ts
@@ -45,7 +45,7 @@ export const initPokemonData = (
     pokemon: Pokemon,
     species: PokemonSpecies,
     evolutions: string[][],
-    abilities: string[],
+    abilities: MyPokemonAbility[],
     generation: string,
     group: string
 ): PokemonData => {

--- a/src/utils/initializers.ts
+++ b/src/utils/initializers.ts
@@ -7,6 +7,7 @@ import LocationData from "@/models/LocationData";
 import MoveData from "@/models/MoveData";
 import NamedResource from "@/models/NamedResource";
 import MyPokemon from "@/models/Pokemon";
+import MyPokemonAbility from "@/models/PokemonAbility";
 import PokemonData from "@/models/PokemonData";
 import PokemonMove from "@/models/PokemonMove";
 import PokemonName from "@/models/PokemonName";
@@ -23,6 +24,7 @@ import {
     Name,
     NamedAPIResource,
     Pokemon,
+    PokemonAbility,
     PokemonMoveVersion,
     PokemonPastType,
     PokemonSpecies,
@@ -228,5 +230,13 @@ export const initNamedResource = (slug: string, name: string): NamedResource => 
     return {
         slug: slug,
         name: name,
+    };
+};
+
+export const initPokemonAbility = (ability: PokemonAbility): MyPokemonAbility => {
+    return {
+        slug: ability.ability.name,
+        hidden: ability.is_hidden,
+        slot: ability.slot,
     };
 };


### PR DESCRIPTION
- Introduce new `PokemonAbility` interface to store non-fetched ability data in `PokemonData`
- Modify `CaughtPokemon` to include a property `abilityNum` to identify the slot of a Pokemon's ability
- Update `SummaryInfo` and `SummaryPage` to use this new interface
- Have all `CaughtPokemon` default to their first ability when caught