### PR TITLE
Make nickname default to Pokemon name

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,6 @@ The most up-to-date version of NuzDocs is currently deployed at: https://nuzdocs
 -   [ ] Nicer alerts for exports
 -   [ ] Double battle indicator
 -   [ ] Required battle indicator
--   [ ] Dynamic default nicknames
 
 ## License
 

--- a/src/components/Run/Box/Box.tsx
+++ b/src/components/Run/Box/Box.tsx
@@ -66,7 +66,7 @@ const Box: React.FC<Props> = (props: Props) => {
     // Close menu and copy set to clipboard
     const handleExport = (pokemon: CaughtPokemon, name: string): void => {
         setActiveIdx(null);
-        exportPokemon(pokemon.pokemon, name, pokemon.nickname);
+        exportPokemon(pokemon.pokemon, name, pokemon.nickname ? pokemon.nickname : "NuzDocs");
     };
 
     // Listen for window resizes to recompute inverted menus when component ready

--- a/src/components/Summary/SummaryHeader/SummaryHeader.tsx
+++ b/src/components/Summary/SummaryHeader/SummaryHeader.tsx
@@ -62,7 +62,7 @@ const SummaryHeader: React.FC<Props> = (props: Props) => {
     // Set the level of the current Pokemon if it exists on component load
     useEffect((): void => {
         if (props.caughtPokemon) {
-            handleChange(props.caughtPokemon.nickname);
+            handleChange(props.caughtPokemon.nickname ? props.caughtPokemon.nickname : props.pokemonData.pokemon.name);
             setPrevID(getAdjacentID(-1));
             setNextID(getAdjacentID(1));
         }

--- a/src/components/Summary/SummaryInfo/SummaryInfo.tsx
+++ b/src/components/Summary/SummaryInfo/SummaryInfo.tsx
@@ -4,7 +4,6 @@ import CaughtPokemon from "@/models/CaughtPokemon";
 import PokemonAbility from "@/models/PokemonAbility";
 import PokemonData from "@/models/PokemonData";
 import { fetchAbilities } from "@/utils/api";
-import { initNamedResource } from "@/utils/initializers";
 import { getListOfNatures } from "@/utils/natures";
 import { getTypeCardSrc } from "@/utils/utils";
 import Image from "next/image";
@@ -37,23 +36,9 @@ const SummaryInfo: React.FC<Props> = (props: Props) => {
         }
     };
 
-    // Get the names of all abilities
-    const getAbilityNames = (): string[] => {
-        return abilities.map((ability: AbilityData) => ability.name);
-    };
-
-    // Convert an ability name to slug
-    const getAbilitySlug = (name: string): string => {
-        return abilities.find((ability: AbilityData) => ability.name === name)!.slug;
-    };
-
     // Set the level of the current Pokemon if it exists on component load
     useEffect(() => {
-        if (props.caughtPokemon.pokemon.level) {
-            setLevel(String(props.caughtPokemon.pokemon.level));
-        } else {
-            setLevel("");
-        }
+        setLevel(props.caughtPokemon.pokemon.level ? String(props.caughtPokemon.pokemon.level) : "");
     }, [props.caughtPokemon]);
 
     // Fetch the ability data for the given Pokemon on component load
@@ -111,7 +96,7 @@ const SummaryInfo: React.FC<Props> = (props: Props) => {
                                   )!.name
                                 : null
                         }
-                        options={getAbilityNames()}
+                        options={abilities.map((ability: AbilityData) => ability.name)}
                         onSelect={(name: string) =>
                             props.onAbilityUpdate(
                                 props.pokemonData.abilities.find(

--- a/src/models/CaughtPokemon.ts
+++ b/src/models/CaughtPokemon.ts
@@ -3,7 +3,7 @@ import Pokemon from "@/models/Pokemon";
 export default interface CaughtPokemon {
     id: string;
     pokemon: Pokemon;
-    nickname: string;
+    nickname?: string;
     locationSlug: string;
     pastSlugs: string[];
     abilityNum: number;

--- a/src/utils/initializers.ts
+++ b/src/utils/initializers.ts
@@ -124,7 +124,6 @@ export const initCaughtPokemon = (pokemon: MyPokemon, locationSlug: string, runI
                 .concat(getRIPs(runID).map((pokemon: CaughtPokemon) => pokemon.id))
         ),
         pokemon: pokemon,
-        nickname: pokemon.species,
         locationSlug: locationSlug,
         pastSlugs: [pokemon.slug],
         abilityNum: 1,


### PR DESCRIPTION
- Make `nickname` property in `CaughtPokemon` optional/default to `null` on initialization
- Have nickname display in `SummaryHeader` default to Pokemon name when no nickname has been given
- Use "NuzDocs" as default tag in `handleExport`